### PR TITLE
Multiprocess the pages generation + improved logging.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ pipenv run python -m mwb . output/
 ```
 
 By default, the builder displays information about the build process. This can be disable with
- the `--silent` switch.
+ the `--silent` switch, or the `--verbose` switch can be used to activate more detailed output.
 
 The builder produces minified HTML. This can be turned off with the `--no-minify` switch. The
 produced HTML can optinally also be prettified with the `--prettify` switch. These are mainly

--- a/mwb/__main__.py
+++ b/mwb/__main__.py
@@ -7,19 +7,17 @@ from .builder import WebsiteBuilder
 parser = ArgumentParser()
 parser.add_argument('srcdir', default='.')
 parser.add_argument('dstdir', default='./public')
-parser.add_argument('--silent', action='store_true',
-                    help="Do not display any info during compilation.")
-parser.add_argument('--verbose', action='store_true',
-                    help="Display all compiled pages, not only errors.")
+parser.add_argument('--silent', action='store_true', help='Do not display any info during compilation.')
+parser.add_argument('--verbose', action='store_true', help='Display all compiled pages, not only errors.')
 parser.add_argument('--prettify', action='store_true')
 parser.add_argument('--no-minify', action='store_true')
 args = parser.parse_args()
 args.minify = not args.no_minify
 
-assert not (args.verbose and args.silent), \
-    "--verbose and --silent cannot be present at the same time"
-
 # Build website
-builder = WebsiteBuilder(path.abspath(args.srcdir), verbose=args.verbose, silent=args.silent,
-                         minify=args.minify, prettify=args.prettify)
+builder = WebsiteBuilder(
+    path.abspath(args.srcdir),
+    verbose=args.verbose, silent=args.silent,
+    minify=args.minify, prettify=args.prettify
+)
 builder.build(path.abspath(args.dstdir))

--- a/mwb/__main__.py
+++ b/mwb/__main__.py
@@ -7,13 +7,19 @@ from .builder import WebsiteBuilder
 parser = ArgumentParser()
 parser.add_argument('srcdir', default='.')
 parser.add_argument('dstdir', default='./public')
-parser.add_argument('--silent', action='store_true')
+parser.add_argument('--silent', action='store_true',
+                    help="Do not display any info during compilation.")
+parser.add_argument('--verbose', action='store_true',
+                    help="Display all compiled pages, not only errors.")
 parser.add_argument('--prettify', action='store_true')
 parser.add_argument('--no-minify', action='store_true')
 args = parser.parse_args()
 args.minify = not args.no_minify
 
+assert not (args.verbose and args.silent), \
+    "--verbose and --silent cannot be present at the same time"
+
 # Build website
-builder = WebsiteBuilder(path.abspath(args.srcdir), verbose=not args.silent,
+builder = WebsiteBuilder(path.abspath(args.srcdir), verbose=args.verbose, silent=args.silent,
                          minify=args.minify, prettify=args.prettify)
 builder.build(path.abspath(args.dstdir))


### PR DESCRIPTION
I did two things:
* Multi-processing the compilation of all pages (> 100 on the virtual edition)
* Improved the logging readability

## Multiprocessing
The main modification was to move the loop content into a dedicated function, `build_page`, and to modify the loops behavior. First, the two `for` loops generate the set of pages to be compiled. Then, we loop over that list, by calling `build_page`.

By using `functools.partial`, we can pre-fill most of the options for `build_page`, and then `map` over it. It becomes easy, from there, to use the `multiprocessing.Pool` to do that in parallel. 

Small caveat: some parts of the `self.` could not be pickled, do I removed the lambda functions. Similar for `self.markdown`. 

I've left commented the standard loop to generate the pages:
```Python
        # for param in params:
        #     prefilled(*param)
        Pool().starmap(prefilled, params)
```

Interestingly, I noticed that even the standard loop is now faster than it used to be.

## Logging
Displaying all generated pages was too much info, and actually hides when a compiling error happens. 
I added explicitely the `--verbose` parameter, and tweaked the behavior a bit:
* `--silent` will remove any and all print
* `--verbose` will add the display of all generated pages.

I also added some small useful info. The default logs now looks like this:
```
>>>  python3 -m mwb . /usr/share/nginx/midl
Preparing output directory /usr/share/nginx/midl
Copying static files
Compiling stylesheets
        > compiling themes/midl-website-theme/stylesheets/fontawesome.scss
        > compiling themes/midl-website-theme/stylesheets/placeholder.scss
        > compiling themes/midl-website-theme/stylesheets/default.scss
Compiling pages
        > Compiled 117 pages in 0.7963230609893799 seconds
```
